### PR TITLE
Add reply workflow and auto-reply simulation

### DIFF
--- a/reputeai/app/models/__init__.py
+++ b/reputeai/app/models/__init__.py
@@ -4,3 +4,5 @@ from .membership import Membership, OrgRole
 from .refresh_token import RefreshToken
 from .integration import Integration
 from .review import Review
+from .reply import Reply
+from .audit_log import AuditLog

--- a/reputeai/app/models/audit_log.py
+++ b/reputeai/app/models/audit_log.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+from sqlalchemy import Column, Integer, String, DateTime, JSON
+
+from ..db.base import Base
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    org_id = Column(Integer, index=True, nullable=False)
+    user_id = Column(Integer, nullable=True)
+    action = Column(String, nullable=False)
+    payload = Column(JSON, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/reputeai/app/models/reply.py
+++ b/reputeai/app/models/reply.py
@@ -1,4 +1,6 @@
-from sqlalchemy import Column, Integer, String
+from datetime import datetime
+
+from sqlalchemy import Column, Integer, String, Boolean, DateTime
 
 from ..db.base import Base
 
@@ -7,4 +9,11 @@ class Reply(Base):
     __tablename__ = "replies"
 
     id = Column(Integer, primary_key=True, index=True)
-    message = Column(String, nullable=False)
+    org_id = Column(Integer, index=True, nullable=False)
+    review_id = Column(Integer, index=True, nullable=False)
+    text = Column(String, nullable=False)
+    is_auto = Column(Boolean, default=False)
+    status = Column(String, default="draft", nullable=False)
+    platform_status = Column(String, nullable=True)
+    posted_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/reputeai/app/schemas/autoreply.py
+++ b/reputeai/app/schemas/autoreply.py
@@ -1,0 +1,17 @@
+from datetime import datetime, time
+
+from pydantic import BaseModel
+
+
+class AutoReplySimulateRequest(BaseModel):
+    rating: int
+    text: str
+    timestamp: datetime
+    min_rating: int = 4
+    blacklist: list[str] = []
+    office_hours_start: time = time(9, 0)
+    office_hours_end: time = time(17, 0)
+
+
+class AutoReplySimulateResponse(BaseModel):
+    eligible: bool

--- a/reputeai/app/schemas/reply.py
+++ b/reputeai/app/schemas/reply.py
@@ -1,8 +1,21 @@
+from datetime import datetime
+
 from pydantic import BaseModel, ConfigDict
 
 
-class Reply(BaseModel):
+class ReplyCreate(BaseModel):
+    text: str
+    is_auto: bool = False
+
+
+class ReplyOut(BaseModel):
     id: int
-    message: str
+    org_id: int
+    review_id: int
+    text: str
+    is_auto: bool
+    status: str
+    platform_status: str | None = None
+    posted_at: datetime | None = None
 
     model_config = ConfigDict(from_attributes=True)

--- a/reputeai/app/services/integrations/base.py
+++ b/reputeai/app/services/integrations/base.py
@@ -18,6 +18,9 @@ class Provider(Protocol):
     def fetch_reviews(self, token: str, since: datetime | None = None) -> list[dict[str, Any]]:
         ...
 
+    def post_reply(self, token: str, review: dict[str, Any], text: str) -> bool:
+        ...
+
 
 _providers: dict[str, Provider] = {}
 
@@ -59,6 +62,9 @@ class DummyProvider:
                 "metadata": {},
             }
         ]
+
+    def post_reply(self, token: str, review: dict[str, Any], text: str) -> bool:
+        return self.name == "google"
 
 
 # Register default providers

--- a/reputeai/app/services/replies.py
+++ b/reputeai/app/services/replies.py
@@ -1,2 +1,84 @@
-def create_reply() -> None:
-    pass
+from datetime import datetime
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from ..models import AuditLog, Integration, Reply, Review
+from .integrations import get_provider
+
+
+def create_reply(
+    db: Session,
+    org_id: int,
+    review_id: int,
+    text: str,
+    is_auto: bool,
+    user_id: int | None,
+) -> Reply:
+    review = db.query(Review).filter_by(id=review_id, org_id=org_id).first()
+    if review is None:
+        raise HTTPException(status_code=404, detail="Review not found")
+    reply = Reply(
+        org_id=org_id,
+        review_id=review_id,
+        text=text,
+        is_auto=is_auto,
+        status="draft",
+    )
+    db.add(reply)
+    db.flush()
+    log = AuditLog(
+        org_id=org_id,
+        user_id=user_id,
+        action="create_reply",
+        payload={"reply_id": reply.id, "text": text},
+    )
+    db.add(log)
+    db.commit()
+    db.refresh(reply)
+    return reply
+
+
+def send_reply(db: Session, org_id: int, review_id: int, user_id: int | None) -> Reply:
+    reply = (
+        db.query(Reply)
+        .filter_by(org_id=org_id, review_id=review_id)
+        .order_by(Reply.id.desc())
+        .first()
+    )
+    if reply is None:
+        raise HTTPException(status_code=404, detail="Reply not found")
+    review = db.query(Review).filter_by(id=review_id, org_id=org_id).first()
+    if review is None:
+        raise HTTPException(status_code=404, detail="Review not found")
+    integration = (
+        db.query(Integration)
+        .filter_by(org_id=org_id, provider=review.platform)
+        .first()
+    )
+    if integration is None:
+        raise HTTPException(status_code=400, detail="Integration not found")
+    provider = get_provider(review.platform)
+    success = False
+    try:
+        success = provider.post_reply(
+            integration.access_token, {"external_id": review.external_id}, reply.text
+        )
+    except Exception:
+        success = False
+    reply.status = "sent"
+    if success:
+        reply.platform_status = "posted"
+        reply.posted_at = datetime.utcnow()
+    else:
+        reply.platform_status = "failed"
+    log = AuditLog(
+        org_id=org_id,
+        user_id=user_id,
+        action="send_reply",
+        payload={"reply_id": reply.id, "success": success},
+    )
+    db.add(log)
+    db.commit()
+    db.refresh(reply)
+    return reply

--- a/tests/test_replies.py
+++ b/tests/test_replies.py
@@ -1,0 +1,89 @@
+from datetime import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from reputeai.app.main import app
+from reputeai.app.db.base import Base
+from reputeai.app.db.session import engine, SessionLocal
+from reputeai.app.models import Org, Integration, Review, AuditLog
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+client = TestClient(app)
+
+
+def seed_data() -> None:
+    with SessionLocal() as db:
+        org = Org(id=1, name="Test")
+        integration = Integration(org_id=1, provider="google", access_token="token")
+        review = Review(
+            id=1,
+            org_id=1,
+            platform="google",
+            external_id="r1",
+            text="Great",
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+        )
+        db.add_all([org, integration, review])
+        db.commit()
+
+
+def test_reply_workflow():
+    seed_data()
+    resp = client.post("/orgs/1/reviews/1/reply", json={"text": "Thanks", "is_auto": False})
+    assert resp.status_code == 200
+    reply = resp.json()
+    assert reply["status"] == "draft"
+
+    resp = client.post("/orgs/1/reviews/1/send-reply")
+    assert resp.status_code == 200
+    sent = resp.json()
+    assert sent["status"] == "sent"
+
+    resp = client.get("/orgs/1/replies", params={"review_id": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+
+    with SessionLocal() as db:
+        logs = db.query(AuditLog).all()
+        assert len(logs) == 2
+
+
+def test_autoreply_simulation():
+    resp = client.post(
+        "/orgs/1/autoreply/simulate",
+        json={
+            "rating": 5,
+            "text": "Great service",
+            "timestamp": "2024-01-01T10:00:00",
+            "min_rating": 4,
+            "blacklist": ["bad"],
+            "office_hours_start": "09:00",
+            "office_hours_end": "17:00",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["eligible"] is True
+
+    resp = client.post(
+        "/orgs/1/autoreply/simulate",
+        json={
+            "rating": 3,
+            "text": "Great service",
+            "timestamp": "2024-01-01T10:00:00",
+            "min_rating": 4,
+            "blacklist": [],
+            "office_hours_start": "09:00",
+            "office_hours_end": "17:00",
+        },
+    )
+    assert resp.json()["eligible"] is False


### PR DESCRIPTION
## Summary
- implement Reply and AuditLog models
- add endpoints for replying to reviews, sending replies, listing replies, and simulating auto-reply rules
- support posting replies via provider protocol and dummy Google implementation

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b04feff7708331b36b270fbc2d1f7b